### PR TITLE
textgrid highlighting for point tiers and absent flag

### DIFF
--- a/syntaxes/textgrid.tmGrammar.json
+++ b/syntaxes/textgrid.tmGrammar.json
@@ -23,15 +23,15 @@
             "name": "string.quoted.double.textgrid"
         },
         {
-            "match": "(x(min|max)|class|name|text|size)",
+            "match": "(x(min|max)|class|name|text|size|number|mark)",
             "name": "constant.language.textgrid"
         },
         {
-            "match": "(intervals|item)",
+            "match": "(intervals|points|item)",
             "name": "entity.name.type.module.textgrid"
         },
         {
-            "match": "(File type|Object class|\\<exists\\>)",
+            "match": "(File type|Object class|\\<exists\\>|\\<absent\\>)",
             "name": "keyword.control.language.textgrid"
         },
         {


### PR DESCRIPTION
in my journey to write textgrid handling code for various languages, i discovered that praatvscode fails to properly highlight both point tiers and the `<absent>` flag for textgrid files. here are some examples

```TextGrid
File type = "ooTextFile"
Object class = "TextGrid"

xmin = 0 
xmax = 2.3510204081632655 
tiers? <exists> 
size = 2 
item []: 
    item [1]:
        class = "IntervalTier" 
        name = "Mary" 
        xmin = 0 
        xmax = 2.3510204081632655 
        intervals: size = 3 
        intervals [1]:
            xmin = 0 
            xmax = 0.7427342752056899 
            text = "1_label1" 
        intervals [2]:
            xmin = 0.7427342752056899 
            xmax = 1.7447703580322245 
            text = "1_label2"
        intervals [3]:
            xmin = 1.7447703580322245 
            xmax = 2.3510204081632655 
            text = "1_label3" 
    item [2]:
        class = "TextTier" 
        name = "Bell" 
        xmin = 0 
        xmax = 2.3510204081632655 
        points: size = 3 
        points [1]:
            number = 0.40238753672840144
            mark = "point1" 
        points [2]:
            number = 1.1677357861976339 
            mark = "point2" 
        points [3]:
            number = 1.8950757704562047 
            mark = "point3" 
```

where the field `points` should have the same highlighting as `intervals`, and `number`, `mark` should have the same highlighting as `x(min)(max)`, `text`.

additionally, although much less important, [the praat manual](https://www.fon.hum.uva.nl/praat/manual/TextGrid_file_formats.html) does state that instead of the `<exists>` flag in the `tiers?` field, that value could also be `<absent>`. 

```TextGrid
File type = "ooTextFile"
Object class = "TextGrid"

xmin = 0 
xmax = 2.3510204081632655 
tiers? <absent>
```

why someone would want to have an empty textgrid with no tiers? i have no idea. but technically its a valid textgrid file! to fix both of these issues, i edited the textgrid TextMate syntax file to handle these fields. i've never worked with TextMate before, so apologies if i did something wrong!