### PR TITLE
Add syntax highlighting injection in markdown and quarto fenced blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 			},
 			{
                 		"id": "praat-markdown-injection"
-            		}
+            		},
 			{
 				"id": "textgrid",
 				"icon": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
 				"configuration": "./praat-language-configuration.json"
 			},
 			{
+                		"id": "praat-markdown-injection"
+            		}
+			{
 				"id": "textgrid",
 				"icon": {
 					"light": "./images/praat_32x32.png",
@@ -80,6 +83,17 @@
 				"language": "textgrid",
 				"scopeName": "source.textgrid",
 				"path": "./syntaxes/textgrid.tmGrammar.json"
+			},
+			{
+			"language": "praat-markdown-injection",
+			"scopeName": "markdown.praat.codeblock",
+			"path": "./syntaxes/praat-markdown-injection.json",
+			"injectTo": [
+				"text.html.markdown"
+			],
+			"embeddedLanguages": {
+				"meta.embedded.block.praat": "praat"
+			}
 			}
 		],
 		"commands": [

--- a/package.json
+++ b/package.json
@@ -53,8 +53,11 @@
 				"configuration": "./praat-language-configuration.json"
 			},
 			{
-                		"id": "praat-markdown-injection"
-            		},
+        "id": "praat-markdown-injection"
+      },
+			{
+        "id": "praat-quarto-injection"
+      },
 			{
 				"id": "textgrid",
 				"icon": {
@@ -85,15 +88,26 @@
 				"path": "./syntaxes/textgrid.tmGrammar.json"
 			},
 			{
-			"language": "praat-markdown-injection",
-			"scopeName": "markdown.praat.codeblock",
-			"path": "./syntaxes/praat-markdown-injection.json",
-			"injectTo": [
-				"text.html.markdown"
-			],
-			"embeddedLanguages": {
-				"meta.embedded.block.praat": "praat"
-			}
+				"language": "praat-markdown-injection",
+				"scopeName": "markdown.praat.codeblock",
+				"path": "./syntaxes/praat-markdown-injection.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.praat": "praat"
+				}
+			},
+			{
+				"language": "praat-quarto-injection",
+				"scopeName": "quarto.praat.codeblock",
+				"path": "./syntaxes/praat-quarto-injection.json",
+				"injectTo": [
+					"text.html.quarto"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.praat": "praat"
+				}
 			}
 		],
 		"commands": [

--- a/praat-quarto-injection.json
+++ b/praat-quarto-injection.json
@@ -1,0 +1,45 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.quarto",
+    "patterns": [
+        {
+            "include": "#praat-code-block"
+        }
+    ],
+    "repository": {
+        "praat-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(praat)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.quarto",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.quarto"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.quarto"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.quarto"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.quarto"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.praat",
+                    "patterns": [
+                        {
+                            "include": "source.praat"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "quarto.praat.codeblock"
+}

--- a/syntaxes/praat-markdown-injection.json
+++ b/syntaxes/praat-markdown-injection.json
@@ -1,0 +1,45 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#praat-code-block"
+        }
+    ],
+    "repository": {
+        "praat-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(praat)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.praat",
+                    "patterns": [
+                        {
+                            "include": "source.praat"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.praat.codeblock"
+}


### PR DESCRIPTION
These changes add support for Praat syntax highlighting in Markdown/Quarto fenced code blocks (```` ```praat ````)